### PR TITLE
chore: ignore .claude/ harness state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .vercel
+
+# Claude Code harness state (per-machine, never commit)
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore` so Claude Code's per-machine harness files (e.g. `settings.local.json`, session metadata) don't appear as untracked in `git status` or get accidentally committed.

## Why

`settings.local.json` is workstation-specific permission/MCP state — committing it would push one developer's local config onto everyone else and leak machine-level settings.

## Test plan

- [ ] `git status` no longer shows `.claude/` as untracked after pulling this branch
- [ ] No existing tracked files are affected (only an addition to `.gitignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)