### PR TITLE
chore: clear biome lint warnings surfaced by 2.x migration

### DIFF
--- a/src/hooks/sitemap.js
+++ b/src/hooks/sitemap.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra');
-const path = require('path');
+const path = require('node:path');
 
 module.exports = [
   {

--- a/src/routes/[property]/route.js
+++ b/src/routes/[property]/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request, params }) => {
+  data: ({ params }) => {
     // Mock property data - in a real app, this would fetch from a database
     const properties = {
       "hs-001": {

--- a/src/routes/community/index.tsx
+++ b/src/routes/community/index.tsx
@@ -63,8 +63,8 @@ export default component$(() => {
                 { icon: '🚶‍♀️', title: 'Walking Trails', description: 'Scenic walking trails throughout the community' },
                 { icon: '🌳', title: 'Parks & Recreation', description: 'Beautiful parks and recreational areas for families' },
                 { icon: '🏛️', title: 'Community Clubhouse', description: 'Elegant clubhouse for events and community gatherings' }
-              ].map((amenity, index) => (
-                <div key={index} class="heritage-card p-6 text-center">
+              ].map((amenity) => (
+                <div key={amenity.title} class="heritage-card p-6 text-center">
                   <div class="text-4xl mb-4">{amenity.icon}</div>
                   <h3 class="text-xl font-semibold mb-3">{amenity.title}</h3>
                   <p class="text-gray-600">{amenity.description}</p>

--- a/src/routes/community/route.js
+++ b/src/routes/community/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request }) => {
+  data: () => {
     return {
       community: {
         name: "Heritage at Stonebridge",

--- a/src/routes/contact/route.js
+++ b/src/routes/contact/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request }) => {
+  data: () => {
     return {
       contactInfo: {
         agentName: "Dr. Jan Duffy",

--- a/src/routes/homes/route.js
+++ b/src/routes/homes/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request }) => {
+  data: () => {
     return {
       availableHomes: [
         {

--- a/src/routes/market-report/route.js
+++ b/src/routes/market-report/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request }) => {
+  data: () => {
     return {
       marketData: {
         currentMonth: "January 2024",

--- a/src/routes/neighborhood/route.js
+++ b/src/routes/neighborhood/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request }) => {
+  data: () => {
     return {
       neighborhood: {
         name: "Summerlin",

--- a/src/routes/sold/route.js
+++ b/src/routes/sold/route.js
@@ -1,5 +1,5 @@
 export default {
-  data: ({ request }) => {
+  data: () => {
     return {
       soldProperties: [
         {


### PR DESCRIPTION
## Summary

Follow-up to [#60](https://github.com/LetMeHelpYouREALTY/StonebridgeHomes/pull/60). Once the Biome 2.x config parse issue was fixed, the linter started walking the source tree and surfaced 8 pre-existing code quality issues that had been masked. None affect runtime behavior — this is pure cleanup.

## Changes

| File(s) | Rule | Fix |
|---|---|---|
| `src/hooks/sitemap.js` | `useNodejsImportProtocol` | `require('path')` → `require('node:path')` (Biome auto-fix with `--unsafe`) |
| `src/routes/*/route.js` (6 files) | `noUnusedFunctionParameters` | drop unused `{ request }` — `data` loaders return static data, framework still calls them the same way |
| `src/routes/[property]/route.js` | `noUnusedFunctionParameters` | drop unused `request`, keep `params` (actually used to look up the property by id) |
| `src/routes/community/index.tsx` | `noArrayIndexKey` | `key={index}` → `key={amenity.title}` in amenities grid — titles are unique and stable across the hardcoded list |

## Verified locally (Node v20.20.0)

- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm run build` — clean Vite build, no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)